### PR TITLE
Update GNU licenses SPDX license identifiers

### DIFF
--- a/src/main/resources/org/psliwa/idea/composerJson/composer-schema.json
+++ b/src/main/resources/org/psliwa/idea/composerJson/composer-schema.json
@@ -630,7 +630,7 @@
     }
   },
   "definitions": {
-    "license": { "enum": [ "MIT", "BSD", "BSD-2.0", "Apache-2.0", "LGPL-3.0", "LGPL-2.1", "GPL-2.0", "GPL-3.0", "proprietary" ] },
+    "license": { "enum": [ "MIT", "BSD", "BSD-2.0", "Apache-2.0", "LGPL-3.0-only", "LGPL-3.0-or-later", "LGPL-2.1-only", "LGPL-2.1-or-later", "GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later", "AGPL-3.0-only", "AGPL-3.0-or-later", "proprietary" ] },
     "package": {
       "type": "object",
       "additionalProperties": true


### PR DESCRIPTION
Some of the SPDX license identifiers of the GNU licenses currently still
in use in this plugin have been deprecated:

> Release 3.0 [of SPDX License List on 28th December 2017] replaced previous
Identifiers for GNU licenses with more explicit Identifiers to reflect
the "this version only" or "any later version" option specific to those
licenses. As such, the previously used Identifiers for those licenses are
deprecated as of v3.0.

(from: [SPDX license list], see as well: [SPDX IDs: How to use])

The following SPDX IDs could be found that are affected by the deprecation:

~~~
"LGPL-3.0", "LGPL-2.1", "GPL-2.0", "GPL-3.0"
~~~

Also for the GNU license IDs the Affero type of license was missing so I
added it.

[SPDX license list]: https://spdx.org/licenses/
[SPDX IDs: How to use]: https://spdx.org/ids-how